### PR TITLE
Fixup links in site footer

### DIFF
--- a/theme/templates/includes/site_footer.html
+++ b/theme/templates/includes/site_footer.html
@@ -9,7 +9,7 @@
                         <i class="fas fa-envelope align-middle footer-icon"></i>
                         info@py.amsterdam
                     </a></p>
-                    <p><a href="https://twitter.com">
+                    <p><a href="https://twitter.com/PyAmsterdam">
                         <i class="fab fa-twitter align-middle footer-icon"></i>
                         @pyamsterdam
                     </a></p>
@@ -22,7 +22,7 @@
                         github.com/PyAmsterdam
                     </a></p>
                     <p>
-                        <a href="https://pyamsterdam.slack.com">
+                        <a href="https://bit.ly/join-pyamsterdam-slack">
                             <i class="fab fa-slack align-middle footer-icon"></i>
                             pyamsterdam.slack.com
                         </a></p>


### PR DESCRIPTION
Link to Twitter profile instead of generic link to Twitter.
Link to Slack join link instead of just workspace.

N. B.: The QR code contains HTTP, instead of HTTPS URL. This is left unfixed as I don't know how to regenerate the code.