### PR TITLE
Switch talk and host submission flows to Zammad

### DIFF
--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -144,6 +144,54 @@
 {% with file='/vendor/jquery-easing/1.4.1/jquery.easing.min.js' %}
     <script src="{{ (SITEURL~'/'~THEME_STATIC_DIR~file)|cachebust(THEME~'/static'~file) }}"></script>
 {% endwith %}
+<script id="zammad_form_script" src="https://pyamsterdam.zammad.com/assets/form/form.js"></script>
+<script>
+    jQuery(function ($) {
+        if (typeof $.fn.ZammadForm !== 'function') {
+            return;
+        }
+
+        function attachZammadForm(selector, overrides) {
+            var $elements = $(selector);
+            if (!$elements.length) {
+                return;
+            }
+
+            $elements.each(function () {
+                var $el = $(this);
+
+                if ($el.data('zammad-initialised')) {
+                    return;
+                }
+
+                $el.ZammadForm($.extend({
+                    modal: true,
+                    showTitle: true,
+                    messageSubmit: 'Submit'
+                }, overrides));
+
+                $el.data('zammad-initialised', true);
+            });
+        }
+
+        attachZammadForm('#zammad-feedback-form', {
+            messageTitle: 'Contact Python Amsterdam',
+            messageThankYou: 'Thank you for your inquiry (#%s)! We\'ll contact you as soon as possible.'
+        });
+
+        attachZammadForm('.zammad-talk-form', {
+            messageTitle: 'Submit a Talk Proposal',
+            messageSubmit: 'Send proposal',
+            messageThankYou: 'Thanks for your talk proposal (#%s)! We\'ll review it and get back to you shortly.'
+        });
+
+        attachZammadForm('.zammad-host-form', {
+            messageTitle: 'Host a PyAmsterdam Event',
+            messageSubmit: 'Offer to host',
+            messageThankYou: 'Thanks for offering your venue (#%s)! We\'ll reach out with next steps soon.'
+        });
+    });
+</script>
 </body>
 
 </html>

--- a/theme/templates/includes/section_what_we_do.html
+++ b/theme/templates/includes/section_what_we_do.html
@@ -54,8 +54,8 @@
             </div>
         </div>
         <div class="row justify-content-center">
-            <a class="btn btn-dark btn-lg mx-1" href="{{ TALK_FORM_URL }}">Submit a talk</a>
-            <a class="btn btn-light btn-lg mx-1" href="{{ HOST_FORM_URL }}">Host an event</a>
+            <button class="btn btn-dark btn-lg mx-1 zammad-talk-form" type="button">Submit a talk</button>
+            <button class="btn btn-light btn-lg mx-1 zammad-host-form" type="button">Host an event</button>
         </div>
     </div>
 </section>

--- a/theme/templates/includes/site_footer.html
+++ b/theme/templates/includes/site_footer.html
@@ -21,10 +21,10 @@
                         <i class="fab fa-github align-middle footer-icon"></i>
                         github.com/PyAmsterdam
                     </a></p>
-                        <a href="https://www.youtube.com/channel/UC2eNRBhT_UX2xB1PSi8gGjw">
-                            <i class="fab fa-youtube align-middle footer-icon"></i>
-                            Py.Amsterdam
-                        </a></p>
+                    <p><a href="https://www.youtube.com/channel/UC2eNRBhT_UX2xB1PSi8gGjw">
+                        <i class="fab fa-youtube align-middle footer-icon"></i>
+                        Py.Amsterdam
+                    </a></p>
                 </div>
                 <div class="col-12 col-md-4">
                     <h3 class="mb-4">More information</h3>
@@ -38,8 +38,16 @@
                     <p>
                         Connect with us to make this community stronger!
                     </p>
-                    <p><a href="{{ TALK_FORM_URL }}">Talk submission form</a>.</p>
-                    <p><a href="{{ HOST_FORM_URL }}">Event host submission form</a>.</p>
+                    <p>
+                        <button class="btn btn-outline-danger btn-sm zammad-talk-form" type="button">
+                            Talk submission form
+                        </button>
+                    </p>
+                    <p>
+                        <button class="btn btn-outline-dark btn-sm zammad-host-form" type="button">
+                            Event host submission form
+                        </button>
+                    </p>
                     <p><a href="{{ SITEURL~'/'~'pages/coc.html#coc' }}">Code of Conduct</a></p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the Google Forms links with Zammad-powered buttons in the services section and footer
- reuse the shared integration script to handle contact, talk, and host forms with tailored copy
- clean up footer markup while wiring the new triggers

## Testing
- source .venv/bin/activate && make html
